### PR TITLE
Fix 400 error when playlist has no name

### DIFF
--- a/spotify2ytmusic/cli.py
+++ b/spotify2ytmusic/cli.py
@@ -310,6 +310,11 @@ def copy_all_playlists():
             continue
 
         pl_name = src_pl["name"]
+        if pl_name is "":
+            # Prevents 400 Bad request when creating new playlist.
+            # I dont know what to put there but yt api doesnt like empty string
+            pl_name = "NO_NAME"
+            
         dst_pl_id = get_playlist_id_by_name(yt, pl_name)
         print(f"Looking up playlist '{pl_name}': id={dst_pl_id}")
         if dst_pl_id is None:


### PR DESCRIPTION
When I synched playlists from spotify to yt music I encountered this error where a playlist of mine didnt have a name. So this will set the name to NO_NAME if the playlist name is an empty string.

I would like it to be some random generated or spotify ID maybe but this is a quick fix for you :) feel free to improve uppon it.