### PR TITLE
fix wrong function call in copy_all_playlists

### DIFF
--- a/spotify2ytmusic/cli.py
+++ b/spotify2ytmusic/cli.py
@@ -209,7 +209,7 @@ def copy_playlist():
             default="utf-8",
             help="The encoding of the `playlists.json` file.",
         )
-        parse_arguments(
+        parser.add_argument(
             "--algo",
             type=int,
             default=0,
@@ -251,7 +251,7 @@ def copy_all_playlists():
             default="utf-8",
             help="The encoding of the `playlists.json` file.",
         )
-        parse_arguments(
+        parser.add_argument(
             "--algo",
             type=int,
             default=0,


### PR DESCRIPTION
`s2yt_copy_all_playlists` fails because there is a call to the wrong function for adding `--algo` to the argument parser.

```
$ s2yt_copy_all_playlists
Traceback (most recent call last):
  File "/home/belzebub/tmp/s2yt/bin/s2yt_copy_all_playlists", line 8, in <module>
    sys.exit(copy_all_playlists())
             ^^^^^^^^^^^^^^^^^^^^
  File "/home/belzebub/tmp/s2yt/lib/python3.11/site-packages/spotify2ytmusic/cli.py", line 263, in copy_all_playlists
    args = parse_arguments()
           ^^^^^^^^^^^^^^^^^
  File "/home/belzebub/tmp/s2yt/lib/python3.11/site-packages/spotify2ytmusic/cli.py", line 254, in parse_arguments
    parse_arguments(
TypeError: copy_all_playlists.<locals>.parse_arguments() got an unexpected keyword argument 'type'
(s2yt) ➜ belzebub@supernova  ~/tmp  s2yt_copy_all_playlists -h
Traceback (most recent call last):
  File "/home/belzebub/tmp/s2yt/bin/s2yt_copy_all_playlists", line 8, in <module>
    sys.exit(copy_all_playlists())
             ^^^^^^^^^^^^^^^^^^^^
  File "/home/belzebub/tmp/s2yt/lib/python3.11/site-packages/spotify2ytmusic/cli.py", line 263, in copy_all_playlists
    args = parse_arguments()
           ^^^^^^^^^^^^^^^^^
  File "/home/belzebub/tmp/s2yt/lib/python3.11/site-packages/spotify2ytmusic/cli.py", line 254, in parse_arguments
    parse_arguments(
TypeError: copy_all_playlists.<locals>.parse_arguments() got an unexpected keyword argument 'type'
```