### PR TITLE
Fixed the tool not creating a new playlist when the provided playlist name does not already exist

### DIFF
--- a/spotify2ytmusic/backend.py
+++ b/spotify2ytmusic/backend.py
@@ -453,7 +453,7 @@ def copy_playlist(
         ytmusic_playlist_id = get_playlist_id_by_name(yt, pl_name)
         print(f"Looking up playlist '{pl_name}': id={ytmusic_playlist_id}")
 
-    if ytmusic_playlist_id == "":
+    if ytmusic_playlist_id is None:
         if pl_name == "":
             print("No playlist name or ID provided, creating playlist...")
             spotify_pls: dict = load_playlists_json()


### PR DESCRIPTION
Hello project maintainers, 

I was using the surgical copy of individual playlists workflow when I discovered that the tool will not create a new playlist in YT music if the provided playlist name does not exist. 

For example, I would run something like:
`python3 -m spotify2ytmusic copy_playlist [SPOTIFY_ID]  '+[NEW_NAME]'`
and if I do not already have a playlist in YT music with NEW_NAME, the Spotify playlist would not be copied across.

The cause of the issue appears to be that get_playlist_id_by_name will return None, instead of the empty string, when the named playlist is not found. I've implemented a one-line fix, and although I have not tested it extensively it seems to be working. 

Thank you for your hard work!