### PR TITLE
Improve speed of copying

### DIFF
--- a/spotify2ytmusic/backend.py
+++ b/spotify2ytmusic/backend.py
@@ -428,9 +428,10 @@ def copier(
                             duplicates=False,
                         )
                 else:
-                    for dst_track in dst_tracks:
-                        yt.rate_song(dst_track, "LIKE")
-                    break
+                    with ThreadPoolExecutor(max_workers=10) as executor:
+                        for dst_track in dst_tracks:
+                            executor.submit(yt.rate_song, dst_track, "LIKE")
+                break
             except Exception as e:
                 print(
                     f"ERROR: (Retrying add_playlist_items: {dst_pl_id} {dst_tracks}) {e} in {exception_sleep} seconds"


### PR DESCRIPTION
This PR:
* parallelize song lookups from Spotify, realize most of the time spent was on this
* add multiple playlist items at once by first querying current playlist to remove duplicate
* and save names of playlist copied, allowing copy all playlist to resume without doing the same work

Some timing comparison--copying my 226 tracks playlist:
```
(spotify_to_ytmusic) ➜  spotify_to_ytmusic git:(main) ✗ python3 -m spotify2ytmusic list_playlists   
== Spotify
5pqr0griqJC66O9wj5eNLr - calm_coding                                        (226 tracks)

== YTMusic
PLvVVJk59GvMqAplKuIIfnH2gfE1ft7TKg - calm_coding                              (0 tracks)

# current HEAD: 6a49e3df36c9797b1afe76ec621cc1b846966266
(spotify_to_ytmusic) ➜  spotify_to_ytmusic git:(main) ✗ time python3 -m spotify2ytmusic copy_playlist 5pqr0griqJC66O9wj5eNLr PLvVVJk59GvMqAplKuIIfnH2gfE1ft7TKg
...
Added 223 tracks, encountered 3 duplicates, 0 errors
python3 -m spotify2ytmusic copy_playlist 5pqr0griqJC66O9wj5eNLr   7.34s user 0.98s system 1% cpu 9:17.85 total

# manually clearing all the tracks copied to YTMusic playlist, running this PR version:
(spotify_to_ytmusic) ➜  spotify_to_ytmusic git:(main) ✗ time python3 -m spotify2ytmusic copy_playlist 5pqr0griqJC66O9wj5eNLr PLvVVJk59GvMqAplKuIIfnH2gfE1ft7TKg
...

Added 223 tracks, encountered 0 duplicates, 0 errors
python3 -m spotify2ytmusic copy_playlist 5pqr0griqJC66O9wj5eNLr   4.58s user 0.68s system 13% cpu 39.449 total
```

From about 9 mins to ~40s. (This was run on Apple M2 Max MacBook Pro with 32GB memory so result might vary)