### PR TITLE
improvement: list available commands for cli

### DIFF
--- a/spotify2ytmusic/__main__.py
+++ b/spotify2ytmusic/__main__.py
@@ -2,16 +2,26 @@
 
 from . import cli
 import sys
+import inspect
+
+def list_commands(module):
+    # include only functions defined in e.g. 'cli' module
+    commands = [name for name, obj in inspect.getmembers(module) if inspect.isfunction(obj)]
+    return commands
+
+available_commands = list_commands(cli)
 
 if len(sys.argv) < 2:
     print(f"usage: spotify2ytmusic [COMMAND] <ARGUMENTS>")
-    print("       For example, try 'list_playlists'")
+    print("Available commands:", ", ".join(available_commands))
+    print("       For example, try 'spotify2ytmusic list_playlists'")
     sys.exit(1)
 
-if not hasattr(cli, sys.argv[1]):
+if sys.argv[1] not in available_commands:
     print(
-        f"ERROR: Unknown command, see https://github.com/linsomniac/spotify_to_ytmusic"
+        f"ERROR: Unknown command '{sys.argv[1]}', see https://github.com/linsomniac/spotify_to_ytmusic"
     )
+    print("Available commands: ", ", ".join(available_commands))
     sys.exit(1)
 
 fn = getattr(cli, sys.argv[1])


### PR DESCRIPTION
Hello!

Thank you for this cool project :) I wanted to make some changes in my fork and realized it's not so easy to know which commands are available from CLI. This change will list all available commands from cli.py

Before:
```
$ python3 -m spotify2ytmusic
usage: spotify2ytmusic [COMMAND] <ARGUMENTS>
       For example, try 'list_playlists'

$ python3 -m spotify2ytmusic main
ERROR: Unknown command, see https://github.com/linsomniac/spotify_to_ytmusic
```

After:
```
$ python3 -m spotify2ytmusic
usage: spotify2ytmusic [COMMAND] <ARGUMENTS>
Available commands: copy_all_playlists, copy_playlist, create_playlist, gui, list_liked_albums, list_playlists, load_liked, load_liked_albums, search, ytoauth
       For example, try 'spotify2ytmusic list_playlists'

$ python3 -m spotify2ytmusic wrong
ERROR: Unknown command 'wrong', see https://github.com/linsomniac/spotify_to_ytmusic
Available commands:  copy_all_playlists, copy_playlist, create_playlist, gui, list_liked_albums, list_playlists, load_liked, load_liked_albums, search, ytoauth
```