### PR TITLE
Handle and skip writing podcast episodes

### DIFF
--- a/spotify2ytmusic/spotify_backup.py
+++ b/spotify2ytmusic/spotify_backup.py
@@ -187,7 +187,7 @@ def main(dump="playlists,liked", format="json", file="playlists.json", token="")
             for playlist in playlists:
                 f.write(playlist["name"] + "\r\n")
                 for track in playlist["tracks"]:
-                    if track["track"] is None:
+                    if track["track"] is None or track["track"]["type"] == "episode":
                         continue
                     f.write(
                         "{name}\t{artists}\t{album}\t{uri}\t{release_date}\r\n".format(


### PR DESCRIPTION
The script broke for me when it hit a podcast episode because `track["track"]["artists"][0]["name"]` was `None`.

Another approach here would be to try to include podcast episodes, but I felt that was likely outside the scope of this project.