### PR TITLE
Skipping playlists created by spotify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ spotify2ytmusic/settings.json
 spotify2ytmusic/test.py
 .idea/
 _backup.json
+.DS_Store

--- a/spotify2ytmusic/spotify_backup.py
+++ b/spotify2ytmusic/spotify_backup.py
@@ -168,6 +168,10 @@ def main(dump="playlists,liked", format="json", file="playlists.json", token="")
 
         # List all tracks in each playlist
         for playlist in playlist_data:
+            if playlist["owner"]["id"] == "spotify":
+                print("Skipping Spotify playlist: {name} ({tracks[total]} songs)".format(**playlist))
+                continue
+
             print("Loading playlist: {name} ({tracks[total]} songs)".format(**playlist))
             playlist["tracks"] = spotify.list(
                 playlist["tracks"]["href"], {"limit": 100}


### PR DESCRIPTION
The playlists that were auto created by spotify were throwing error while downloading. This left the script to go in retrial and halt eventually. 

This small change will skip the scripts that have owner.id = spotify. 

Also updated gitignore file for macos.
