### PR TITLE
calling xterm fails, so execute the command directly

### DIFF
--- a/spotify2ytmusic/gui.py
+++ b/spotify2ytmusic/gui.py
@@ -320,16 +320,13 @@ class Window:
                 else:  # For Unix and Linux
                     try:
                         subprocess.call(
-                            "x-terminal-emulator -e ytmusicapi oauth",
+                            "ytmusicapi oauth",
                             shell=True,
                             stdout=subprocess.PIPE,
                         )
-                    except:
-                        subprocess.call(
-                            "xterm -e ytmusicapi oauth",
-                            shell=True,
-                            stdout=subprocess.PIPE,
-                        )
+                    except Exception as e:
+                        print(f"An error occurred: {e}")
+
 
             self.tabControl.select(self.tab2)
             print()

--- a/spotify2ytmusic/gui.py
+++ b/spotify2ytmusic/gui.py
@@ -320,7 +320,7 @@ class Window:
                 else:  # For Unix and Linux
                     try:
                         subprocess.call(
-                            "ytmusicapi oauth",
+                            "python3 -m ytmusicapi oauth",
                             shell=True,
                             stdout=subprocess.PIPE,
                         )


### PR DESCRIPTION
attempting to call x-terminal-emulator fails and it doesn't call xterm, so why not execute the `ytmusicapi oauth` command directly?
Closes #86 
Closes #90
Closes #78 