### PR TITLE
Fixed HTTP Error 404: Not Found on track loading

### DIFF
--- a/spotify2ytmusic/spotify_backup.py
+++ b/spotify2ytmusic/spotify_backup.py
@@ -152,9 +152,7 @@ def main(dump="playlists,liked", format="json", file="playlists.json", token="")
     # List liked albums and songs
     if "liked" in dump:
         print("Loading liked albums and songs...")
-        liked_tracks = spotify.list(
-            "users/{user_id}/tracks".format(user_id=user_id_escaped), {"limit": 50}
-        )
+        liked_tracks = spotify.list("me/tracks", {"limit": 50})
         liked_albums = spotify.list("me/albums", {"limit": 50})
         playlists += [{"name": "Liked Songs", "tracks": liked_tracks}]
 


### PR DESCRIPTION
This looks like a new problem.
The fix is based on the documentation found [here](https://developer.spotify.com/documentation/web-api/reference/get-users-saved-tracks)