### PR TITLE
Set liked songs sorting to reversed by default

### DIFF
--- a/spotify2ytmusic/cli.py
+++ b/spotify2ytmusic/cli.py
@@ -186,10 +186,10 @@ def load_liked():
             help="Algorithm to use for search (0 = exact, 1 = extended, 2 = approximate)",
         )
         parser.add_argument(
-            "--reverse-playlist",
+            "--no-reverse-playlist",
             action="store_true",
-            help="Reverse playlist on load, normally this is not set for liked songs as "
-            "they are added in the opposite order from other commands in this program.",
+            help="Do not reverse playlist on load, regular playlists are reversed normally "
+            "so they end up in the same order as on Spotify.",
         )
 
         return parser.parse_args()
@@ -200,7 +200,7 @@ def load_liked():
         backend.iter_spotify_playlist(
             None,
             spotify_encoding=args.spotify_playlists_encoding,
-            reverse_playlist=args.reverse_playlist,
+            reverse_playlist=not args.no_reverse_playlist,
         ),
         None,
         args.dry_run,


### PR DESCRIPTION
Changed `--reverse-playlist` to `--no-reverse-playlist` when loading liked songs.
Like for playlists, when liking songs you expect the oldest to be liked first.