### PR TITLE
docs: update README with tkinter installation check to prevent issues on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,24 @@ This is a set of scripts for copying "liked" songs and playlists from Spotify to
    python3 -m pip uninstall spotify2ytmusic
    ```
 
+3. **Verify installation of tkinter** (many linux distros don't include tkinter despite
+   being in the python standard library).
+
+    On Ubuntu/Debian:
+    ```bash
+    sudo apt-get install python3-tk
+    ```
+
+    On Fedora:
+    ```bash
+    sudo dnf install python3-tkinter
+    ```
+
+    On Arch Linux:
+    ```bash
+    sudo pacman -S tk
+    ```
+
 ---
 
 ### Setup Instructions


### PR DESCRIPTION
I was using this tool and got hung up on tkinter dependency. Linux doesn't include tkinter by default (or at least Debian doesn't) so I updated the README to install tkinter before proceeding