### PR TITLE
Update README to add Tkinter installation step before running GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,18 @@ The GUI will **ignore the 'Login to YT Music' tab** and jump straight to the 'Sp
 
 ---
 
-#### 3. Use the GUI for Migration
+#### 3. Install tkinter (Required for GUI on Linux (Ubuntu/Debian))
+
+If you're using Linux, you'll need to install tkinter before using the GUI:
+
+```bash
+sudo apt-get update
+sudo apt-get install python3-tk
+```
+
+---
+
+#### 4. Use the GUI for Migration
 
 Now you can use the graphical user interface (GUI) to migrate your playlists and liked songs to YouTube Music. Start the GUI with the following command:
 


### PR DESCRIPTION
On Ubuntu, running the GUI (step 3) fails with `ModuleNotFoundError: No module named 'tkinter'`
if Tkinter is not installed system-wide. This update adds instructions to install `python3-tk`
before running the GUI to prevent error.