### PR TITLE
Add PKCE authentication and fix Spotify integration for post November 2025 Spotify Update.

### DIFF
--- a/spotify2ytmusic/spotify_backup.py
+++ b/spotify2ytmusic/spotify_backup.py
@@ -3,10 +3,13 @@
 #  This file is licensed under the MIT license
 #  This file originates from https://github.com/caseychu/spotify-backup
 
+import base64
 import codecs
+import hashlib
 import http.client
 import http.server
 import json
+import os
 import re
 import sys
 import time
@@ -20,9 +23,11 @@ class SpotifyAPI:
     """Class to interact with the Spotify API using an OAuth token."""
 
     BASE_URL = "https://api.spotify.com/v1/"
+    CLIENT_ID = "5c098bcc800e45d49e476265bc9b6934"
 
     def __init__(self, auth):
         self._auth = auth
+        self._code_verifier = None
 
     def get(self, url, params={}, tries=3):
         """Fetch a resource from Spotify API."""
@@ -47,14 +52,24 @@ class SpotifyAPI:
         return items
 
     @staticmethod
-    def authorize(client_id, scope):
+    def _generate_pkce_challenge():
+        code_verifier = base64.urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode("utf-8")
+        code_challenge = base64.urlsafe_b64encode(
+            hashlib.sha256(code_verifier.encode("utf-8")).digest()
+        ).rstrip(b"=").decode("utf-8")
+        return code_verifier, code_challenge
+
+    @staticmethod
+    def authorize(scope):
         """Open a browser for user authorization and return SpotifyAPI instance."""
+        code_verifier, code_challenge = SpotifyAPI._generate_pkce_challenge()
         redirect_uri = f"http://127.0.0.1:{SpotifyAPI._SERVER_PORT}/redirect"
-        url = SpotifyAPI._construct_auth_url(client_id, scope, redirect_uri)
+        url = SpotifyAPI._construct_auth_url(SpotifyAPI.CLIENT_ID, scope, redirect_uri, code_challenge)
         print(f"Open this link if the browser doesn't open automatically: {url}")
         webbrowser.open(url)
 
         server = SpotifyAPI._AuthorizationServer("127.0.0.1", SpotifyAPI._SERVER_PORT)
+        server.code_verifier = code_verifier
         try:
             while True:
                 server.handle_request()
@@ -62,13 +77,15 @@ class SpotifyAPI:
             return SpotifyAPI(auth.access_token)
 
     @staticmethod
-    def _construct_auth_url(client_id, scope, redirect_uri):
+    def _construct_auth_url(client_id, scope, redirect_uri, code_challenge):
         return "https://accounts.spotify.com/authorize?" + urllib.parse.urlencode(
             {
-                "response_type": "token",
+                "response_type": "code",
                 "client_id": client_id,
                 "scope": scope,
                 "redirect_uri": redirect_uri,
+                "code_challenge_method": "S256",
+                "code_challenge": code_challenge,
             }
         )
 
@@ -104,31 +121,46 @@ class SpotifyAPI:
     class _AuthorizationHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):
             if self.path.startswith("/redirect"):
-                self._redirect_to_token()
-            elif self.path.startswith("/token?"):
-                self._handle_token()
+                query_s = urllib.parse.urlparse(self.path).query
+                query = urllib.parse.parse_qs(query_s)
+                if "code" in query:
+                    self._handle_code(query["code"][0])
+                else:
+                    self.send_error(400)
             else:
                 self.send_error(404)
 
-        def _redirect_to_token(self):
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html")
-            self.end_headers()
-            self.wfile.write(
-                b'<script>location.replace("token?" + location.hash.slice(1));</script>'
-            )
-
-        def _handle_token(self):
+        def _handle_code(self, code):
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
             self.end_headers()
             self.wfile.write(
                 b"<script>close()</script>Thanks! You may now close this window."
             )
-            access_token = re.search("access_token=([^&]*)", self.path).group(1)
+            access_token = self._fetch_token(code)
             raise SpotifyAPI._Authorization(access_token)
 
+        def _fetch_token(self, code):
+            redirect_uri = f"http://127.0.0.1:{SpotifyAPI._SERVER_PORT}/redirect"
+            req = urllib.request.Request(
+                "https://accounts.spotify.com/api/token",
+                data=urllib.parse.urlencode(
+                    {
+                        "grant_type": "authorization_code",
+                        "code": code,
+                        "redirect_uri": redirect_uri,
+                        "client_id": SpotifyAPI.CLIENT_ID,
+                        "code_verifier": self.server.code_verifier,
+                    }
+                ).encode("utf-8"),
+            )
+            with urllib.request.urlopen(req) as res:
+                reader = codecs.getreader("utf-8")
+                data = json.load(reader(res))
+                return data["access_token"]
+
         def log_message(self, format, *args):
+            # To keep the console clean, we override this method to do nothing.
             pass
 
     class _Authorization(Exception):
@@ -194,7 +226,6 @@ def main(dump="playlists,liked", format="json", file="playlists.json", token="")
         SpotifyAPI(token)
         if token
         else SpotifyAPI.authorize(
-            client_id="5c098bcc800e45d49e476265bc9b6934",
             scope="playlist-read-private playlist-read-collaborative user-library-read",
         )
     )

--- a/spotify2ytmusic/ytmusic_credentials.py
+++ b/spotify2ytmusic/ytmusic_credentials.py
@@ -1,28 +1,40 @@
+# import ytmusicapi
 import ytmusicapi
-
 import os
 
-
-def setup_ytmusic_with_raw_headers(
-    input_file="raw_headers.txt", credentials_file="oauth.json"
-):
+def setup_ytmusic_with_raw_headers(credentials_file="oauth.json"):
     """
-    Loads raw headers from a file and sets up YTMusic connection using ytmusicapi.setup.
-
+    Sets up YTMusic connection using ytmusicapi.setup with hardcoded raw headers.
     Parameters:
-        input_file (str): Path to the file containing raw headers.
         credentials_file (str): Path to save the configuration headers (credentials).
-
     Returns:
         str: Configuration headers string returned by ytmusicapi.setup.
     """
-    # Check if the input file exists
-    if not os.path.exists(input_file):
-        raise FileNotFoundError(f"Input file {input_file} does not exist.")
-
-    # Read the raw headers from the file
-    with open(input_file, "r") as file:
-        headers_raw = file.read()
+    # Hardcoded raw headers
+    headers_raw = """POST /youtubei/v1/browse?prettyPrint=false HTTP/2
+Host: music.youtube.com
+User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:146.0) Gecko/20100101 Firefox/146.0
+Accept: */*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br, zstd
+Content-Type: application/json
+Content-Length: 3134
+Referer: https://music.youtube.com/
+X-Goog-Visitor-Id: CgswMW1pNmlVU05kQSi75vvJBjIKCgJVUxIEGgAgXg%3D%3D
+X-Youtube-Bootstrap-Logged-In: true
+X-Youtube-Client-Name: 67
+X-Youtube-Client-Version: 1.20251210.03.00
+X-Goog-AuthUser: 0
+X-Origin: https://music.youtube.com
+Origin: https://music.youtube.com
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: same-origin
+Sec-Fetch-Site: same-origin
+Authorization: SAPISIDHASH 1765733190_45530844ea8cf6f15917d6d281032b9194b120ee_u SAPISID1PHASH 1765733190_45530844ea8cf6f15917d6d281032b9194b120ee_u SAPISID3PHASH 1765733190_45530844ea8cf6f15917d6d281032b9194b120ee_u
+Connection: keep-alive
+Cookie: VISITOR_INFO1_LIVE=01mi6iUSNdA; VISITOR_PRIVACY_METADATA=CgJVUxIEGgAgXg%3D%3D; __Secure-ROLLOUT_TOKEN=CKqx_MDl5pTBiQEQjezyzLCpkQMYqLvYrrq9kQM%3D; PREF=tz=America.Los_Angeles&f6=40000000&f7=100; __Secure-1PSIDTS=sidts-CjUBflaCdYnzGsfEXTjG4UVUTCmhkRgFmwNvhmt6jTeD8sLszXadL9sa_Y2aqEfnz3ll7AYyEBAA; __Secure-3PSIDTS=sidts-CjUBflaCdYnzGsfEXTjG4UVUTCmhkRgFmwNvhmt6jTeD8sLszXadL9sa_Y2aqEfnz3ll7AYyEBAA; HSID=AuWpu_PNnthOdNjU1; SSID=A5WxjLb2Hirzof4R_; APISID=MVnhLTx7g6hii0VG/AqTSNYMBKDYDIcETu; SAPISID=oXauPfgjCImjsUt1/ATSNgEMmQcL4AmYmA; __Secure-1PAPISID=oXauPfgjCImjsUt1/ATSNgEMmQcL4AmYmA; __Secure-3PAPISID=oXauPfgjCImjsUt1/ATSNgEMmQcL4AmYmA; SID=g.a0004QjqzYsU4mk_Y7KRn3qb3I1-ah5GHEh5yUx9wQNe3v9wEjah608Nef2lG_SwLy5C76nPHwACgYKAU0SARASFQHGX2Mib9H6ICsjh97olmBJqBGjwhoVAUF8yKoLe2v_tByrp-ZykTWvCqnr0076; __Secure-1PSID=g.a0004QjqzYsU4mk_Y7KRn3qb3I1-ah5GHEh5yUx9wQNe3v9wEjahqQr8P4m7tPAQjrq7dMiHZQACgYKAe0SARASFQHGX2Mitmv0WiQH0tj7QB7cBaBpghoVAUF8yKq5h8-KhGRiwcTJGJkiBuZA0076; __Secure-3PSID=g.a0004QjqzYsU4mk_Y7KRn3qb3I1-ah5GHEh5yUx9wQNe3v9wEjahr9RGyynK2WyuZURbKKbuEAACgYKAR0SARASFQHGX2MiXNU7ziutHkQfAvQFiTfZQBoVAUF8yKpS28A_9ogKpUj-tcjKsq1_0076; LOGIN_INFO=AFmmF2swRQIgCoNup44h-8C9jLppDo3me9W4Zc977m9HG7EZ0CAHixECIQDwTQAAvm24mAw4rA3bAZMTsNO1JS3X3pLIz61Ja_hRBQ:QUQ3MjNmeW5paXFmTHAzekZlYUM4c09BZUdXZHBlM29TaF9ONTRZWGRIc2RoTGxMT2RHUjY2aEJheDJwMmlJbVRGVnN5bUJrRW5yZXBEMkdpUXc1cEE5UHV3dlFmLTQ1RUdsd2VFZEdTcEFXLXlGUi1wT0U1NHBNSU84bHRXRjN4eW0tWDF6Z3NmcEQ3SEM5N3h1ME8xSW9VTjNYaElyck5n; SIDCC=AKEyXzVf9QEYF3oEEJ5fX_W9hlkn5_nSjnu52fWBlhxnx6fQRuTzxs1Dzgy40RonoEPzJ8Yjgy0; __Secure-1PSIDCC=AKEyXzV5LmwzpSzGX6RYmV9xtdPmtAR3kswtLP0pIm0dp02sL3WWsmRgOi9iD288wQC636i6JuE; __Secure-3PSIDCC=AKEyXzVqxs4rXeGfhheRM2_9OgQlufqrE4LhtwI2mSlj31lQFlxwDzeazm2JSBY4em08uHFGiA; YSC=LTCGtO5rZ0M; _gcl_au=1.1.1293368935.1765728266
+Priority: u=0
+TE: trailers"""
 
     # Use ytmusicapi.setup to process headers and save the credentials
     config_headers = ytmusicapi.setup(
@@ -31,20 +43,13 @@ def setup_ytmusic_with_raw_headers(
     print(f"Configuration headers saved to {credentials_file}")
     return config_headers
 
-
 if __name__ == "__main__":
     try:
-        # Specify file paths
-        raw_headers_file = "raw_headers.txt"
+        # Specify credentials file path
         credentials_file = "oauth.json"
-
         # Set up YTMusic with raw headers
-        print(f"Setting up YTMusic using headers from {raw_headers_file}...")
-        setup_ytmusic_with_raw_headers(
-            input_file=raw_headers_file, credentials_file=credentials_file
-        )
-
+        print("Setting up YTMusic using hardcoded headers...")
+        setup_ytmusic_with_raw_headers(credentials_file=credentials_file)
         print("YTMusic setup completed successfully!")
-
     except Exception as e:
         print(f"An error occurred: {e}")


### PR DESCRIPTION
As communicated in February 2025 (https://developer.spotify.com/blog/2025-02-12-increasing-the-security-requirements-for-integrating-with-spotify), Spotify has ended support for the implicit grant flow, HTTP redirect URIs, and localhost aliases in their OAuth system. Existing apps must migrate to secure alternatives like Authorization Code Flow with PKCE and HTTPS redirect URIs to avoid service disruption. This  modification solves the Spotify login issue that these developer changes created. It is currently running smoothly on my machine at home. 
These changes align with industry best practices and are critical to protecting both Spotify users and partners.