### PR TITLE
Fix Spotify OAuth flow with PKCE

### DIFF
--- a/spotify2ytmusic/backend.py
+++ b/spotify2ytmusic/backend.py
@@ -133,6 +133,18 @@ def iter_spotify_playlist(
     """
     spotify_pls = load_playlists_json(spotify_playlist_file, spotify_encoding)
 
+    def normalize_spotify_playlist_id(raw_id: Optional[str]) -> Optional[str]:
+        if raw_id is None:
+            return None
+        cleaned = raw_id.strip()
+        match = re.match(r"^spotify:playlist:([A-Za-z0-9]+)$", cleaned)
+        if match:
+            return match.group(1)
+        match = re.search(r"open\.spotify\.com/playlist/([A-Za-z0-9]+)", cleaned)
+        if match:
+            return match.group(1)
+        return cleaned
+
     def find_spotify_playlist(spotify_pls: Dict, src_pl_id: Union[str, None]) -> Dict:
         """Return the spotify playlist that matches the `src_pl_id`.
 
@@ -140,12 +152,18 @@ def iter_spotify_playlist(
             `spotify_pls`: The playlist datastrcuture saved by spotify-backup.
             `src_pl_id`: The ID of a playlist to find, or None for the "Liked Songs" playlist.
         """
+        normalized_id = normalize_spotify_playlist_id(src_pl_id)
         for src_pl in spotify_pls["playlists"]:
             if src_pl_id is None and str(src_pl.get("name")) == "Liked Songs":
                 return src_pl
-            if src_pl_id is not None and str(src_pl.get("id")) == src_pl_id:
+            if normalized_id is not None and str(src_pl.get("id")) == normalized_id:
                 return src_pl
-        raise ValueError(f"Could not find Spotify playlist {src_pl_id}")
+        msg = f"Could not find Spotify playlist {src_pl_id}"
+        if normalized_id is not None and normalized_id != src_pl_id:
+            msg += f" (normalized to {normalized_id})"
+        if src_pl_id and re.match(r"^(PL|RD|OL)", src_pl_id):
+            msg += ". That looks like a YouTube playlist ID; use a Spotify playlist ID or URL."
+        raise ValueError(msg)
 
     src_pl = find_spotify_playlist(spotify_pls, src_pl_id)
     src_pl_name = src_pl["name"]

--- a/spotify2ytmusic/spotify_backup.py
+++ b/spotify2ytmusic/spotify_backup.py
@@ -4,9 +4,12 @@
 #  This file originates from https://github.com/caseychu/spotify-backup
 
 import codecs
+import base64
+import hashlib
 import http.client
 import http.server
 import json
+import os
 import re
 import sys
 import time
@@ -50,26 +53,55 @@ class SpotifyAPI:
     def authorize(client_id, scope):
         """Open a browser for user authorization and return SpotifyAPI instance."""
         redirect_uri = f"http://127.0.0.1:{SpotifyAPI._SERVER_PORT}/redirect"
-        url = SpotifyAPI._construct_auth_url(client_id, scope, redirect_uri)
+        code_verifier = SpotifyAPI._generate_code_verifier()
+        code_challenge = SpotifyAPI._generate_code_challenge(code_verifier)
+        url = SpotifyAPI._construct_auth_url(
+            client_id,
+            scope,
+            redirect_uri,
+            response_type="code",
+            code_challenge=code_challenge,
+            code_challenge_method="S256",
+        )
         print(f"Open this link if the browser doesn't open automatically: {url}")
         webbrowser.open(url)
 
-        server = SpotifyAPI._AuthorizationServer("127.0.0.1", SpotifyAPI._SERVER_PORT)
+        server = SpotifyAPI._AuthorizationServer(
+            "127.0.0.1",
+            SpotifyAPI._SERVER_PORT,
+            client_id,
+            redirect_uri,
+            code_verifier,
+        )
         try:
             while True:
                 server.handle_request()
         except SpotifyAPI._Authorization as auth:
             return SpotifyAPI(auth.access_token)
+        except SpotifyAPI._AuthorizationError as err:
+            sys.exit(f"Authorization failed: {err.message}")
 
     @staticmethod
-    def _construct_auth_url(client_id, scope, redirect_uri):
+    def _construct_auth_url(
+        client_id,
+        scope,
+        redirect_uri,
+        response_type="code",
+        code_challenge=None,
+        code_challenge_method=None,
+    ):
+        params = {
+            "response_type": response_type,
+            "client_id": client_id,
+            "scope": scope,
+            "redirect_uri": redirect_uri,
+        }
+        if code_challenge:
+            params["code_challenge"] = code_challenge
+        if code_challenge_method:
+            params["code_challenge_method"] = code_challenge_method
         return "https://accounts.spotify.com/authorize?" + urllib.parse.urlencode(
-            {
-                "response_type": "token",
-                "client_id": client_id,
-                "scope": scope,
-                "redirect_uri": redirect_uri,
-            }
+            params
         )
 
     def _construct_url(self, url, params):
@@ -92,10 +124,22 @@ class SpotifyAPI:
             reader = codecs.getreader("utf-8")
             return json.load(reader(res))
 
+    @staticmethod
+    def _generate_code_verifier():
+        return base64.urlsafe_b64encode(os.urandom(64)).decode("ascii").rstrip("=")
+
+    @staticmethod
+    def _generate_code_challenge(code_verifier):
+        digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+        return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
     _SERVER_PORT = 43019
 
     class _AuthorizationServer(http.server.HTTPServer):
-        def __init__(self, host, port):
+        def __init__(self, host, port, client_id, redirect_uri, code_verifier):
+            self.client_id = client_id
+            self.redirect_uri = redirect_uri
+            self.code_verifier = code_verifier
             super().__init__((host, port), SpotifyAPI._AuthorizationHandler)
 
         def handle_error(self, request, client_address):
@@ -104,29 +148,82 @@ class SpotifyAPI:
     class _AuthorizationHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):
             if self.path.startswith("/redirect"):
-                self._redirect_to_token()
+                self._handle_code()
             elif self.path.startswith("/token?"):
                 self._handle_token()
             else:
                 self.send_error(404)
 
-        def _redirect_to_token(self):
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html")
-            self.end_headers()
-            self.wfile.write(
-                b'<script>location.replace("token?" + location.hash.slice(1));</script>'
-            )
-
-        def _handle_token(self):
+        def _handle_code(self):
+            parsed = urllib.parse.urlparse(self.path)
+            params = urllib.parse.parse_qs(parsed.query)
+            code = params.get("code", [None])[0]
+            if not code:
+                error = params.get("error", ["missing_code"])[0]
+                self.send_response(400)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(
+                    f"Authorization failed: {error}".encode("utf-8", "replace")
+                )
+                raise SpotifyAPI._AuthorizationError(error)
+            access_token = self._exchange_code_for_token(code)
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
             self.end_headers()
             self.wfile.write(
                 b"<script>close()</script>Thanks! You may now close this window."
             )
-            access_token = re.search("access_token=([^&]*)", self.path).group(1)
             raise SpotifyAPI._Authorization(access_token)
+
+        def _handle_token(self):
+            parsed = urllib.parse.urlparse(self.path)
+            params = urllib.parse.parse_qs(parsed.query)
+            access_token = params.get("access_token", [None])[0]
+            if not access_token:
+                error = params.get("error", ["missing_access_token"])[0]
+                self.send_response(400)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(
+                    f"Authorization failed: {error}".encode("utf-8", "replace")
+                )
+                raise SpotifyAPI._AuthorizationError(error)
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(
+                b"<script>close()</script>Thanks! You may now close this window."
+            )
+            raise SpotifyAPI._Authorization(access_token)
+
+        def _exchange_code_for_token(self, code):
+            data = urllib.parse.urlencode(
+                {
+                    "client_id": self.server.client_id,
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": self.server.redirect_uri,
+                    "code_verifier": self.server.code_verifier,
+                }
+            ).encode("utf-8")
+            req = urllib.request.Request(
+                "https://accounts.spotify.com/api/token",
+                data=data,
+                method="POST",
+            )
+            req.add_header("Content-Type", "application/x-www-form-urlencoded")
+            try:
+                with urllib.request.urlopen(req) as res:
+                    reader = codecs.getreader("utf-8")
+                    payload = json.load(reader(res))
+            except urllib.error.HTTPError as err:
+                payload = err.read().decode("utf-8", "replace")
+                raise SpotifyAPI._AuthorizationError(payload)
+            access_token = payload.get("access_token")
+            if not access_token:
+                raise SpotifyAPI._AuthorizationError("missing_access_token")
+            return access_token
 
         def log_message(self, format, *args):
             pass
@@ -134,6 +231,10 @@ class SpotifyAPI:
     class _Authorization(Exception):
         def __init__(self, access_token):
             self.access_token = access_token
+
+    class _AuthorizationError(Exception):
+        def __init__(self, message):
+            self.message = message
 
 
 def fetch_user_data(spotify, dump):


### PR DESCRIPTION
 ## Summary
  - Switch Spotify auth to OAuth code + PKCE flow.
  - Handle `/redirect?code=...` and exchange for access token.
  - Improve error messaging on auth failures.