### PR TITLE
Fix Spotify OAuth (PKCE) and improve YTM header setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ will not duplicate entries on the playlist.
 if the application was installed, which takes the form of: `s2yt_load_liked`
 
 If not fully installed, you can replace the "s2yt\_" with "python -m spotify2ytmusic", for
-example: `s2yt_load_liked` becomes `python -j spotify2ytmusic load_liked`
+example: `s2yt_load_liked` becomes `python3 -m spotify2ytmusic load_liked`
 
 ### Login to YTMusic
 

--- a/spotify2ytmusic/spotify_backup.py
+++ b/spotify2ytmusic/spotify_backup.py
@@ -3,11 +3,13 @@
 #  This file is licensed under the MIT license
 #  This file originates from https://github.com/caseychu/spotify-backup
 
+import base64
 import codecs
-import http.client
+import hashlib
 import http.server
 import json
-import re
+import secrets
+import string
 import sys
 import time
 import urllib.error
@@ -47,14 +49,58 @@ class SpotifyAPI:
         return items
 
     @staticmethod
+    def _pkce_verifier() -> str:
+        alphabet = string.ascii_letters + string.digits + "-._~"
+        return "".join(secrets.choice(alphabet) for _ in range(64))
+
+    @staticmethod
+    def _pkce_challenge(verifier: str) -> str:
+        digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+    @staticmethod
+    def _exchange_code_for_token(
+        client_id: str, code: str, redirect_uri: str, code_verifier: str
+    ) -> str:
+        data = urllib.parse.urlencode(
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": client_id,
+                "code_verifier": code_verifier,
+            }
+        ).encode("ascii")
+        req = urllib.request.Request(
+            "https://accounts.spotify.com/api/token",
+            data=data,
+            method="POST",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        try:
+            with urllib.request.urlopen(req) as res:
+                body = json.load(res)
+        except urllib.error.HTTPError as e:
+            err = e.read().decode("utf-8", errors="replace")
+            sys.exit(f"Spotify token exchange failed ({e.code}): {err}")
+        return body["access_token"]
+
+    @staticmethod
     def authorize(client_id, scope):
         """Open a browser for user authorization and return SpotifyAPI instance."""
         redirect_uri = f"http://127.0.0.1:{SpotifyAPI._SERVER_PORT}/redirect"
-        url = SpotifyAPI._construct_auth_url(client_id, scope, redirect_uri)
+        code_verifier = SpotifyAPI._pkce_verifier()
+        code_challenge = SpotifyAPI._pkce_challenge(code_verifier)
+        url = SpotifyAPI._construct_auth_url(
+            client_id, scope, redirect_uri, code_challenge
+        )
         print(f"Open this link if the browser doesn't open automatically: {url}")
         webbrowser.open(url)
 
         server = SpotifyAPI._AuthorizationServer("127.0.0.1", SpotifyAPI._SERVER_PORT)
+        server.spotify_client_id = client_id
+        server.spotify_redirect_uri = redirect_uri
+        server.spotify_code_verifier = code_verifier
         try:
             while True:
                 server.handle_request()
@@ -62,13 +108,15 @@ class SpotifyAPI:
             return SpotifyAPI(auth.access_token)
 
     @staticmethod
-    def _construct_auth_url(client_id, scope, redirect_uri):
+    def _construct_auth_url(client_id, scope, redirect_uri, code_challenge):
         return "https://accounts.spotify.com/authorize?" + urllib.parse.urlencode(
             {
-                "response_type": "token",
+                "response_type": "code",
                 "client_id": client_id,
                 "scope": scope,
                 "redirect_uri": redirect_uri,
+                "code_challenge_method": "S256",
+                "code_challenge": code_challenge,
             }
         )
 
@@ -104,29 +152,37 @@ class SpotifyAPI:
     class _AuthorizationHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self):
             if self.path.startswith("/redirect"):
-                self._redirect_to_token()
-            elif self.path.startswith("/token?"):
-                self._handle_token()
+                self._handle_redirect()
             else:
                 self.send_error(404)
 
-        def _redirect_to_token(self):
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html")
-            self.end_headers()
-            self.wfile.write(
-                b'<script>location.replace("token?" + location.hash.slice(1));</script>'
+        def _handle_redirect(self):
+            parsed = urllib.parse.urlparse(self.path)
+            q = urllib.parse.parse_qs(parsed.query)
+            if "error" in q:
+                msg = (q.get("error_description") or q["error"] or ["unknown"])[0]
+                self.send_response(400)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(msg.encode("utf-8"))
+                return
+            if "code" not in q:
+                self.send_error(400, "Missing authorization code")
+                return
+            code = q["code"][0]
+            token = SpotifyAPI._exchange_code_for_token(
+                self.server.spotify_client_id,
+                code,
+                self.server.spotify_redirect_uri,
+                self.server.spotify_code_verifier,
             )
-
-        def _handle_token(self):
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
             self.end_headers()
             self.wfile.write(
                 b"<script>close()</script>Thanks! You may now close this window."
             )
-            access_token = re.search("access_token=([^&]*)", self.path).group(1)
-            raise SpotifyAPI._Authorization(access_token)
+            raise SpotifyAPI._Authorization(token)
 
         def log_message(self, format, *args):
             pass

--- a/spotify2ytmusic/ytmusic_credentials.py
+++ b/spotify2ytmusic/ytmusic_credentials.py
@@ -1,6 +1,50 @@
+import os
+import re
+
 import ytmusicapi
 
-import os
+
+def _headers_from_curl_bash(curl_text: str) -> str:
+    """
+    ytmusicapi.setup expects Firefox-style lines 'name: value'. Chrome's
+    'Copy as cURL' uses -H 'name: value' and -b '...', which that parser
+    does not understand. Convert cURL paste into the expected format.
+    """
+    lines: list[str] = []
+
+    m = re.search(r"-b\s+'([^']*)'", curl_text)
+    if m:
+        lines.append(f"cookie: {m.group(1)}")
+    else:
+        m = re.search(r'-b\s+"((?:\\.|[^"\\])*)"', curl_text)
+        if m:
+            lines.append(f"cookie: {re.sub(r'\\(.)', r'\1', m.group(1))}")
+
+    for m in re.finditer(r"-H\s+'([^']*)'", curl_text):
+        part = m.group(1)
+        if ":" not in part:
+            continue
+        name, value = part.split(":", 1)
+        lines.append(f"{name.strip()}: {value.strip()}")
+
+    for m in re.finditer(r'-H\s+"((?:\\.|[^"\\])*)"', curl_text):
+        part = re.sub(r'\\(.)', r"\1", m.group(1))
+        if ":" not in part:
+            continue
+        name, value = part.split(":", 1)
+        lines.append(f"{name.strip()}: {value.strip()}")
+
+    return "\n".join(lines)
+
+
+def _normalize_headers_raw(raw: str) -> str:
+    s = raw.strip()
+    if s.lower().startswith("curl "):
+        converted = _headers_from_curl_bash(raw)
+        if not converted.strip():
+            return raw
+        return converted
+    return raw
 
 
 def setup_ytmusic_with_raw_headers(
@@ -22,7 +66,7 @@ def setup_ytmusic_with_raw_headers(
 
     # Read the raw headers from the file
     with open(input_file, "r") as file:
-        headers_raw = file.read()
+        headers_raw = _normalize_headers_raw(file.read())
 
     # Use ytmusicapi.setup to process headers and save the credentials
     config_headers = ytmusicapi.setup(


### PR DESCRIPTION
## Summary

Spotify’s authorization endpoint no longer accepts the **implicit grant** (`response_type=token`). Users see **`response_type must be code`** when running backup from the GUI or CLI. This updates `spotify_backup.py` to use **authorization code + PKCE** (no client secret), then exchange the code for an access token.

## Additional changes

- **`ytmusic_credentials.py`**: Normalize **Chrome “Copy as cURL”** pastes into the Firefox-style `name: value` lines that `ytmusicapi.setup` expects, so users are not forced to use Firefox-only copy steps.
- **`README.md`**: Fix the module example (`python3 -m spotify2ytmusic …`; the README had a typo `-j`).

## Testing

- [x] `python3 -m py_compile` on touched modules
- Manual: Spotify backup / GUI backup after browser login completes and redirects to `http://127.0.0.1:43019/redirect?code=...`

Upstream redirect URI for the bundled `client_id` must remain `http://127.0.0.1:43019/redirect` in the Spotify app settings (unchanged from before).

---

Fork branch: `Kritarth-Dandapat:fix/spotify-oauth-pkce-and-ytmusic-setup`